### PR TITLE
ChatSpace用データベース設計（README上にて）

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :user
-- belongs_to :group
+- belongs_to :users
+- belongs_to :groups
 
-## userテーブル
+## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -48,9 +48,10 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
-- has_many :group, through: :groups_users
+- has_many :groups, through: :groups_users
+- has_many :groups_users
 
-## groupテーブル
+## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -58,7 +59,8 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
-- has_many :user, through: :groups_users
+- has_many :users, through: :groups_users
+- has_many :groups_users
 
 ## groups_usersテーブル
 
@@ -68,5 +70,5 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
-- belongs_to :user
+- belongs_to :groups
+- belongs_to :users

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Things you may want to cover:
 
 * ...
 
+DB設計
+
 ## messagesテーブル
 
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,49 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## userテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|e-mail|string|null: false|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :group, through: :groups_users
+
+## groupテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :user, through: :groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :users
-- belongs_to :groups
+- belongs_to :user
+- belongs_to :group
 
 ## usersテーブル
 
@@ -70,5 +70,5 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :groups
-- belongs_to :users
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-DB設計
+# DB設計
 
 ## messagesテーブル
 


### PR DESCRIPTION
# WHAT
ChatSpaceのデータベース設計をREADME上にて記載しました。
messages、user、group、groups_usersの4つのテーブルを用意しました。
# WHY
ChatSpaceのデータベースを本格実装する前にテーブルの作成が正しいかを確認してもらうため、READMEにて記載。